### PR TITLE
ci: add UBI mlmd server build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,31 @@
+name: Container Image Build
+on:
+  pull_request:
+    paths-ignore:
+      - 'LICENSE*'
+      - '**.gitignore'
+      - '**.md'
+      - '**.txt'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/dependabot.yml'
+      - 'docs/**'
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate Tag
+        shell: bash
+        id: tags
+        run: |
+          commit_sha=${{ github.event.after }}
+          tag=main-${commit_sha:0:7}
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+      - name: Build Image
+        shell: bash
+        env:
+          DOCKER_IMAGE_REPO: quay.io/opendatahub/mlmd-grpc-server
+          DOCKER_IMAGE_TAG: ${{ steps.tags.outputs.tag }}
+          DOCKER_FILE: Dockerfile.redhat
+        run: ./ml_metadata/tools/docker_server/build_docker_image.sh

--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -29,7 +29,6 @@ RUN mkdir /bazel && \
     cd / && \
     rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
 
-
 COPY . /mlmd-src
 WORKDIR /mlmd-src
 
@@ -45,7 +44,7 @@ RUN bazel build -c opt --action_env=PATH \
 RUN mkdir -p /mlmd-src/third_party
 RUN cp -RL /mlmd-src/bazel-mlmd-src/external/libmysqlclient /mlmd-src/third_party/mariadb-connector-c
 
-FROM registry.redhat.io/ubi8/ubi-minimal:8.9
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9
 
 COPY --from=builder /mlmd-src/bazel-bin/ml_metadata/metadata_store/metadata_store_server /bin/metadata_store_server
 COPY --from=builder /mlmd-src/third_party /mlmd-src/third_party


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Setup simple CI that triggers the UBI mlmd server build, this way we can check the redhat based build would work

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally using nektos/act tool, specifically its `gh` extension:

```bash
gh act pull_request
[Container Image Build/build-image] 🚀  Start image=catthehacker/ubuntu:act-latest
INFO[0000] Parallel tasks (0) below minimum, setting to 1 
[Container Image Build/build-image]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[Container Image Build/build-image] using DockerAuthConfig authentication for docker pull
INFO[0001] Parallel tasks (0) below minimum, setting to 1 
[Container Image Build/build-image]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Container Image Build/build-image]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[] network="host"
[Container Image Build/build-image] ⭐ Run Main actions/checkout@v4
[Container Image Build/build-image]   🐳  docker cp src=/home/alampare/repos/ml-metadata/. dst=/home/alampare/repos/ml-metadata
[Container Image Build/build-image]   ✅  Success - Main actions/checkout@v4
[Container Image Build/build-image] ⭐ Run Main Generate Tag
[Container Image Build/build-image]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/tags.sh] user= workdir=
[Container Image Build/build-image]   ✅  Success - Main Generate Tag
[Container Image Build/build-image]   ⚙  ::set-output:: tag=main-
[Container Image Build/build-image] ⭐ Run Main Build Image
[Container Image Build/build-image]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2.sh] user= workdir=
| ++ DOCKER_IMAGE_REPO=quay.io/opendatahub/mlmd-grpc-server
| ++ DOCKER_IMAGE_TAG=main-
| ++ DOCKER_FILE=Dockerfile.redhat
| ++ docker build -t quay.io/opendatahub/mlmd-grpc-server:main- -f ml_metadata/tools/docker_server/Dockerfile.redhat .
[+] Building 885.8s (18/18) FINISHED                             docker:default
|  => [internal] load build definition from Dockerfile.redhat                0.1s
|  => => transferring dockerfile: 2.31kB                                     0.0s
|  => [internal] load metadata for registry.access.redhat.com/ubi8/ubi-mini  0.6s
|  => [internal] load metadata for registry.access.redhat.com/ubi8/ubi:8.9   0.6s
|  => [internal] load .dockerignore                                          0.1s
|  => => transferring context: 108B                                          0.0s
|  => CACHED [builder 1/9] FROM registry.access.redhat.com/ubi8/ubi:8.9@sha  0.0s
|  => [stage-1 1/4] FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9@sh  0.0s
|  => [internal] load build context                                          0.1s
|  => => transferring context: 3.42MB                                        0.0s
|  => [builder 2/9] RUN dnf update -y -q &&   dnf install -y -q   which     44.5s
|  => [builder 3/9] RUN mkdir /bazel &&     cd /bazel &&     curl -H "User-  2.2s
|  => [builder 4/9] COPY . /mlmd-src                                         0.2s
|  => [builder 5/9] WORKDIR /mlmd-src                                        0.1s
|  => [builder 6/9] RUN bazel build -c opt --action_env=PATH   --define=g  836.5s
|  => [builder 7/9] RUN mkdir -p /mlmd-src/third_party                       0.7s
|  => [builder 8/9] RUN cp -RL /mlmd-src/bazel-mlmd-src/external/libmysqlcl  0.7s
|  => CACHED [stage-1 2/4] COPY --from=builder /mlmd-src/bazel-bin/ml_metad  0.0s
|  => CACHED [stage-1 3/4] COPY --from=builder /mlmd-src/third_party /mlmd-  0.0s
|  => CACHED [stage-1 4/4] RUN microdnf update -y &&   microdnf install -y   0.0s
|  => exporting to image                                                     0.0s
|  => => exporting layers                                                    0.0s
|  => => writing image sha256:e4e0c3fb40599f8a8af63a0e441110445c07efe9e576a  0.0s
|  => => naming to quay.io/opendatahub/mlmd-grpc-server:main-                0.0s
[Container Image Build/build-image]   ✅  Success - Main Build Image
[Container Image Build/build-image] Cleaning up container for job build-image
[Container Image Build/build-image] 🏁  Job succeeded
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
