### PR TITLE
fix: sqlite query config escaping

### DIFF
--- a/ml_metadata/metadata_store/sqlite_metadata_source.cc
+++ b/ml_metadata/metadata_store/sqlite_metadata_source.cc
@@ -174,7 +174,7 @@ absl::Status SqliteMetadataSource::RollbackImpl() {
 }
 
 std::string SqliteMetadataSource::EscapeString(absl::string_view value) const {
-  return SqliteEscapeString(value);
+  return absl::StrCat("'", SqliteEscapeString(value), "'");
 }
 
 std::string SqliteMetadataSource::EncodeBytes(absl::string_view value) const {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://issues.redhat.com/browse/RHOAIENG-3496

## Description
Fixes an issue introduced with the [string escaping](https://github.com/opendatahub-io/ml-metadata/pull/2/):

I experienced he following issue by starting the mlmd server (image `quay.io/opendatahub/mlmd-grpc-server:main-ec2c7b1`) together with `sqlite` configuration.
```
ARNING: Logging before InitGoogleLogging() is written to STDERR                                                                                                                          [15:31:43]
F0221 14:31:43.422607     1 metadata_store_server_main.cc:611] Check failed: absl::OkStatus() == status (OK vs. INTERNAL: Error when executing query: no such column: mlmd.Dataset query:  SELECT `id`, `name`, `version`, `description`,         `input_type`, `output_type` FROM `Type`  WHERE name IN (mlmd.Dataset, mlmd.Model, mlmd.Metrics, mlmd.Statistics) AND version IS NULL AND type_kind = 1; ) MetadataStore cannot be created with the given connection config.
*** Check failure stack trace: ***
```

The sqlite config I used is the same used in model registry: https://github.com/opendatahub-io/model-registry/blob/main/test/config/ml-metadata/conn_config.pb for testing purposes.

Since I am not expert on the codebase I don't know if this fix is going to revert the issue fixed with https://github.com/opendatahub-io/ml-metadata/pull/2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Build local image and run model registry test using the `sqlite` configuration.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
