### PR TITLE
Fix tzdata installation

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -54,7 +54,7 @@ ENV METADATA_STORE_SERVER_CONFIG_FILE ""
 
 # Introduces tzdata package here to avoid LoadTimeZone check failed error in the metadata store server.
 RUN microdnf update -y && \
-  microdnf install -y \
+  microdnf reinstall -y \
   tzdata
 
 ENTRYPOINT \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes https://issues.redhat.com/browse/RHOAIENG-3497

## Description
<!--- Describe your changes in detail -->

Ensure `tzdata` is installed, it seems this change fixes:

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0221 17:26:55.092358     1 metadata_store_server_main.cc:577] Server listening on 0.0.0.0:8080
2024-02-21 17:27:15  FATAL  analyzer_options.cc : 229 : Check failed: absl::LoadTimeZone("America/Los_Angeles", &default_timezone_) 
2024-02-21 17:27:15  FATAL  analyzer_options.cc : 229 : Check failed: absl::LoadTimeZone("America/Los_Angeles", &default_timezone_) 
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
