### PR TITLE
Fix PostgreSQL Metadata Source Tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "string": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "string": "cpp"
+    }
+}

--- a/ml_metadata/metadata_store/metadata_source_test_suite.cc
+++ b/ml_metadata/metadata_store/metadata_source_test_suite.cc
@@ -69,8 +69,8 @@ TEST_P(MetadataSourceTestSuite, TestInsertWithEscapedStringValue) {
   EXPECT_EQ(absl::OkStatus(), metadata_source_->Begin());
   EXPECT_EQ(absl::OkStatus(),
             metadata_source_->ExecuteQuery(
-                absl::StrCat("INSERT INTO t1 VALUES (1, '",
-                             metadata_source_->EscapeString("''"), "')"),
+                absl::StrCat("INSERT INTO t1 VALUES (1, ",
+                             metadata_source_->EscapeString("''"), ")"),
                 nullptr));
   RecordSet expected_results = ParseTextProtoOrDie<RecordSet>(
       R"(column_names: "c1"

--- a/ml_metadata/metadata_store/postgresql_metadata_source.cc
+++ b/ml_metadata/metadata_store/postgresql_metadata_source.cc
@@ -252,7 +252,7 @@ absl::Status PostgreSQLMetadataSource::ConnectImpl() {
     MLMD_RETURN_IF_ERROR(databaseExistenceStatus);
     if (record_set.records_size() == 0) {
       const std::string create_database_cmd =
-          absl::Substitute("CREATE DATABASE $0;", config_.dbname().data());
+          absl::Substitute("CREATE DATABASE \"$0\";", config_.dbname().data());
       PGresult* res = PQexec(connDefault, create_database_cmd.c_str());
       if (PQresultStatus(res) != PGRES_COMMAND_OK &&
           PQresultStatus(res) != PGRES_TUPLES_OK) {

--- a/ml_metadata/metadata_store/test_postgresql_standalone_metadata_source_initializer.cc
+++ b/ml_metadata/metadata_store/test_postgresql_standalone_metadata_source_initializer.cc
@@ -107,7 +107,7 @@ class TestPostgreSQLStandaloneMetadataSourceInitializer
                          .c_str());
     PQclear(res);
     res =
-        PQexec(conn, absl::StrCat("DROP DATABASE IF EXISTS ", db_name).c_str());
+        PQexec(conn, absl::StrCat("DROP DATABASE IF EXISTS \"", db_name, "\"").c_str());
     PQclear(res);
     PQfinish(conn);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates Metadata Source Tests after changes from [commit](https://github.com/google/ml-metadata/commit/b0db34cefa074eb1d8fdb1aa9695f027af6e2f59)

Updates database creation and deletion commands (PSQL specific)  
## Description
<!--- Describe your changes in detail -->
Changes in [commit](https://github.com/google/ml-metadata/commit/b0db34cefa074eb1d8fdb1aa9695f027af6e2f59) no longer require EscapeString to be surrounded by single quotes.

Previously, databases cannot be created or deleted with the name "model-registry" due to "-". PR surrounds database name in double quotes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed model-registry-operator with a postgres server and ran `standalone_postgresql_metadata_source_test`. All 7 tests pass.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
