### PR TITLE
fix missing fields when ordering by

### DIFF
--- a/ml_metadata/metadata_store/postgresql_query_executor.cc
+++ b/ml_metadata/metadata_store/postgresql_query_executor.cc
@@ -903,7 +903,7 @@ absl::Status PostgreSQLQueryExecutor::ListNodeIDsUsingOptions(
                        sql_gen_status.message()));
     }
     sql_query = absl::Substitute(
-        "SELECT distinct $0.id, $0.create_time_since_epoch FROM $1 WHERE $2 "
+        "SELECT distinct $0.id, $0.create_time_since_epoch, $0.last_update_time_since_epoch FROM $1 WHERE $2 "
         "AND ",
         *node_table_alias,
         // TODO(b/257334039): remove query_version-conditional logic

--- a/ml_metadata/metadata_store/query_config_executor.cc
+++ b/ml_metadata/metadata_store/query_config_executor.cc
@@ -844,7 +844,7 @@ absl::Status QueryConfigExecutor::ListNodeIDsUsingOptions(
                        sql_gen_status.message()));
     }
     sql_query = absl::Substitute(
-        "SELECT distinct $0.`id` FROM $1 WHERE $2 AND ", *node_table_alias,
+        "SELECT distinct $0.`id`, $0.`create_time_since_epoch`, $0.`last_update_time_since_epoch` FROM $1 WHERE $2 AND ", *node_table_alias,
         // TODO(b/257334039): remove query_version-conditional logic
         query_builder.GetFromClause(query_version),
         query_builder.GetWhereClause());


### PR DESCRIPTION
## Description

Related: kubeflow/model-registry#358

## How Has This Been Tested?
Tested locally by deploying with kind. Attempted to order various context queries.

```py
from model_registry import ModelRegistry
import contextlib

mr = ModelRegistry("http://localhost", 8080, author="me", is_secure=False)

with contextlib.suppress(Exception):
    mr.register_model(
        "model1",
        "s3",
        version="1",
        model_format_name="1",
        model_format_version="2",
    )
with contextlib.suppress(Exception):
    mr.register_model(
        "model",
        "s3",
        version="2",
        model_format_name="1",
        model_format_version="2",
    )
with contextlib.suppress(Exception):
    mr.register_model(
        "model",
        "s3",
        version="3",
        model_format_name="1",
        model_format_version="2",
    )
with contextlib.suppress(Exception):
    mr.register_model(
        "model2",
        "s3",
        version="1",
        model_format_name="1",
        model_format_version="2",
    )
with contextlib.suppress(Exception):
    mr.register_model(
        "model",
        "s3",
        version="1",
        model_format_name="1",
        model_format_version="2",
    )


print("Registered models by id")
for model in mr.get_registered_models().limit(1):
    print(model)

print("Registered models by create")
for model in mr.get_registered_models().order_by_creation_time().descending().limit(1):
    print(model)

print("Registered models by update")
for model in mr.get_registered_models().order_by_update_time().limit(1):
    print(model)


print("model versions by id")
for model in mr.get_model_versions("model").limit(1):
    print(model)

print("model versions by create")
for model in (
    mr.get_model_versions("model").order_by_creation_time().descending().limit(1)
):
    print(model)

print("model versions by update")
for model in mr.get_model_versions("model").order_by_update_time().limit(1):
    print(model)

```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
