### PR TITLE
fix: set USER in Dockerfile.redhat

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest as builder
+FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
 
 USER root
 
@@ -56,6 +56,8 @@ ENV METADATA_STORE_SERVER_CONFIG_FILE ""
 RUN microdnf update -y && \
   microdnf reinstall -y \
   tzdata
+
+USER 65534:65534
 
 ENTRYPOINT \
   "/bin/metadata_store_server" \


### PR DESCRIPTION
## Description

Set a default, non-root, USER in the container image.

https://issues.redhat.com/browse/RHOAIENG-22051

## How Has This Been Tested?
Built the image and verified that the server still runs in a container. Also pushed it to my dev cluster registry and verified that model-registry works with this image.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
