### PR TITLE
bump dockerfile.redhat to ubi9 and patch zetasql to a newer commit

### DIFF
--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
+FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
 
 USER root
 
@@ -32,6 +32,15 @@ RUN mkdir /bazel && \
 COPY . /mlmd-src
 WORKDIR /mlmd-src
 
+# Patch zetasql commit for UBI9 compatibility
+ENV PREVIOUS_ZETASQL_COMMIT ac37cf5c0d80b5605176fc0f29e87b12f00be693
+ENV PREVIOUS_ZETASQL_SHA 651a768cd51627f58aa6de7039aba9ddab22f4b0450521169800555269447840
+ENV CURRENT_ZETASQL_COMMIT f764f4e986ac1516ab5ae95e6d6ce2f4416cc6ff
+ENV CURRENT_ZETASQL_SHA 27e3d8bfd1f76918fc4d7a8f29646b8a0cdca567f921e0bff4a07f79448e92c0
+RUN \
+    sed -i "s/$PREVIOUS_ZETASQL_COMMIT/$CURRENT_ZETASQL_COMMIT/g" WORKSPACE && \
+    sed -i "s/$PREVIOUS_ZETASQL_SHA/$CURRENT_ZETASQL_SHA/g" WORKSPACE
+
 # Running in offline mode with --nofetch arg, cache and deps must be cloned 
 # into the local root bazel cache
 # "-std=c++17" is needed in order to build with ZetaSQL.
@@ -44,7 +53,7 @@ RUN bazel build -c opt --action_env=PATH \
 RUN mkdir -p /mlmd-src/third_party
 RUN cp -RL /mlmd-src/bazel-mlmd-src/external/libmysqlclient /mlmd-src/third_party/mariadb-connector-c
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /mlmd-src/bazel-bin/ml_metadata/metadata_store/metadata_store_server /bin/metadata_store_server
 COPY --from=builder /mlmd-src/third_party /mlmd-src/third_party


### PR DESCRIPTION
The downstream Dockerfile.konflux has been bumped to ubi9 and the WORKSPACE file was patched directly in a release branch, so now we have a mixed state of broken dockerfiles there.

This patch attempts to bring consistency between Dockerfile.redhat and the downstream .konflux file by patching the WORKSPACE file right before the build so that the upstream (ubuntu based) dockerfile or the fedora dockerfile do not require any changes.