### PR TITLE
Added GCC-11 and Power support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,6 +8,7 @@ http_archive(
     build_file = "//ml_metadata:postgresql.BUILD",
     workspace_file_content = "//ml_metadata:postgresql.WORKSPACE",
     sha256 = "1cb8e3a59861be5175878159fc3a41240c379e9aabaabba8288e6cfd6980fff0",
+    patches = ["//ml_metadata/third_party:postgresql.patch"],
     strip_prefix = "postgresql-12.17",
     urls = [
         "https://ftp.postgresql.org/pub/source/v12.17/postgresql-12.17.tar.gz",
@@ -52,10 +53,10 @@ http_archive(
 
 http_archive(
     name = "boringssl",
-    sha256 = "f69738ca17f1dd30ae3ddb1fa7519245044737d27c8a3defa7a94718d9dfd724",
-    strip_prefix = "boringssl-68dcc7f7b816e199c8f373ea0a2d6a4e1f526e2d",
+    sha256 = "579cb415458e9f3642da0a39a72f79fdfe6dc9c1713b3a823f1e276681b9703e",
+    strip_prefix = "boringssl-648cbaf033401b7fe7acdce02f275b06a88aab5c",
     urls = [
-        "https://github.com/google/boringssl/archive/68dcc7f7b816e199c8f373ea0a2d6a4e1f526e2d.tar.gz",
+        "https://github.com/google/boringssl/archive/648cbaf033401b7fe7acdce02f275b06a88aab5c.tar.gz",
     ],
 )
 

--- a/ml_metadata/metadata_store/metadata_store.py
+++ b/ml_metadata/metadata_store/metadata_store.py
@@ -17,6 +17,8 @@ Provides access to a SQLite3 or a MySQL backend. Artifact types and execution
 types can be created on the fly.
 """
 
+from absl import flags
+flags.FLAGS(['pytest'])
 import enum
 import random
 import time

--- a/ml_metadata/third_party/postgresql.patch
+++ b/ml_metadata/third_party/postgresql.patch
@@ -1,0 +1,37 @@
+diff --git src/port/pg_bitutils.c src/port/pg_bitutils.c
+index 7847e8a..17714af 100644
+--- src/port/pg_bitutils.c
++++ src/port/pg_bitutils.c
+@@ -12,12 +12,14 @@
+  */
+ #include "c.h"
+ 
++#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__)
+ #ifdef HAVE__GET_CPUID
+ #include <cpuid.h>
+ #endif
+ #ifdef HAVE__CPUID
+ #include <intrin.h>
+ #endif
++#endif
+ 
+ #include "port/pg_bitutils.h"
+ 
+@@ -141,6 +143,7 @@ int			(*pg_popcount64) (uint64 word) = pg_popcount64_slow;
+ static bool
+ pg_popcount_available(void)
+ {
++#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__)
+ 	unsigned int exx[4] = {0, 0, 0, 0};
+ 
+ #if defined(HAVE__GET_CPUID)
+@@ -152,6 +155,9 @@ pg_popcount_available(void)
+ #endif
+ 
+ 	return (exx[2] & (1 << 23)) != 0;	/* POPCNT */
++#else
++	return false;
++#endif
+ }
+ 
+ /*

--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -37,6 +37,7 @@ WORKDIR /mlmd-src
 # "-std=c++17" is needed in order to build with ZetaSQL.
 RUN bazel build -c opt --action_env=PATH \
   --define=grpc_no_ares=true \
+  --copt="-Wno-maybe-uninitialized" \
   //ml_metadata/metadata_store:metadata_store_server \
   --cxxopt="-std=c++17" --host_cxxopt="-std=c++17"
 


### PR DESCRIPTION
This pull request addresses build issues encountered on Power architecture with GCC-11, specifically related to the following components: pg_bitutils.c (PostgreSQL), m4, and BoringSSL. The fixes ensure better compatibility and successful compilation on Power systems using GCC-11.

**Summary of Changes**
1. Power Architecture Support – PostgreSQL Patch

A patch has been added to resolve a build error in pg_bitutils.c encountered specifically on Power architecture.
Patch location: //ml_metadata/third_party:postgresql.patch

2. GCC-11 Compatibility Fix – m4 Patch
Resolved the following compilation error in c-stack.c when building m4 with GCC-11:
error:
missing binary operator before token "(" #elif HAVE_LIBSIGSEGV && SIGSTKSZ < 16384

Upstream patch taken from Debian sources:
https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/m4/1.4.18-5ubuntu1/m4_1.4.18-5ubuntu1.debian.tar.xz
Patch location: ml_metadata/third_party:zetasql.patch

3. Boringssl Update for GCC-11
A build error was encountered with the previous version of BoringSSL on Power architecture using GCC-11.
The issue was resolved by upgrading the boringssl version.
Update location: WORKSPACE file

4. Test Case Fix for Abseil (absl)
Patch location: ml_metadata/metadata_store/metadata_store.py

**Purpose of this PR:**
These changes are necessary to ensure successful builds of ml_metadata on Power architecture with GCC-11. They improve cross-platform compatibility and ensure smoother CI/CD integration for platforms using newer compilers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions and integrity checks for improved reliability.
  * Applied a patch to enhance compatibility with certain CPU architectures.
  * Suppressed specific compiler warnings in the Red Hat-based server build.
  * Improved initialization of configuration flags for testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->