### PR TITLE
Use bazel5 RPM; add aarch64 to postgresql patch

### DIFF
--- a/ml_metadata/third_party/postgresql.patch
+++ b/ml_metadata/third_party/postgresql.patch
@@ -6,7 +6,7 @@ index 7847e8a..17714af 100644
   */
  #include "c.h"
  
-+#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__)
++#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__) && !defined(__aarch64__) && !defined(__AARCH64__) && !defined(__arm64__) && !defined(__ARM64__)
  #ifdef HAVE__GET_CPUID
  #include <cpuid.h>
  #endif
@@ -21,7 +21,7 @@ index 7847e8a..17714af 100644
  static bool
  pg_popcount_available(void)
  {
-+#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__)
++#if !defined(__ppc__) && !defined(__PPC__) && !defined(__ppc64__) && !defined(__PPC64__) && !defined(__aarch64__) && !defined(__AARCH64__) && !defined(__arm64__) && !defined(__ARM64__)
  	unsigned int exx[4] = {0, 0, 0, 0};
  
  #if defined(HAVE__GET_CPUID)

--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -11,7 +11,8 @@ RUN curl -o /etc/yum.repos.d/copr-galileo-bazel.repo \
     clang \
     cmake \
     make \
-    openssl \
+    openssl-devel \
+    libcurl-devel \
     ca-certificates \
     unzip \
     git \

--- a/ml_metadata/tools/docker_server/Dockerfile.redhat
+++ b/ml_metadata/tools/docker_server/Dockerfile.redhat
@@ -2,32 +2,22 @@ FROM registry.access.redhat.com/ubi9/ubi:latest AS builder
 
 USER root
 
-RUN dnf update -y -q && \
-  dnf install -y -q \
-  which \
-  patch \
-  gcc \
-  clang \
-  cmake \
-  make \
-  openssl \
-  ca-certificates \
-  unzip \
-  git \
-  findutils \
-  python3
-
-# Set up Bazel 5.3.0
-ENV BAZEL_VERSION 5.3.0
-WORKDIR /
-RUN mkdir /bazel && \
-    cd /bazel && \
-    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -O https://github.com/bazelbuild/bazel/releases/download/$BAZEL_VERSION/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
-    curl -H "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36" -fSsL -o /bazel/LICENSE.txt https://raw.githubusercontent.com/bazelbuild/bazel/master/LICENSE && \
-    chmod +x bazel-*.sh && \
-    ./bazel-$BAZEL_VERSION-installer-linux-x86_64.sh && \
-    cd / && \
-    rm -f /bazel/bazel-$BAZEL_VERSION-installer-linux-x86_64.sh
+RUN curl -o /etc/yum.repos.d/copr-galileo-bazel.repo \
+    https://copr.fedorainfracloud.org/coprs/galileo/bazel/repo/epel-9/galileo-bazel-epel-9.repo && \
+    dnf install -y \
+    which \
+    patch \
+    gcc \
+    clang \
+    cmake \
+    make \
+    openssl \
+    ca-certificates \
+    unzip \
+    git \
+    findutils \
+    python3 \
+    bazel5
 
 COPY . /mlmd-src
 WORKDIR /mlmd-src
@@ -41,7 +31,7 @@ RUN \
     sed -i "s/$PREVIOUS_ZETASQL_COMMIT/$CURRENT_ZETASQL_COMMIT/g" WORKSPACE && \
     sed -i "s/$PREVIOUS_ZETASQL_SHA/$CURRENT_ZETASQL_SHA/g" WORKSPACE
 
-# Running in offline mode with --nofetch arg, cache and deps must be cloned 
+# Running in offline mode with --nofetch arg, cache and deps must be cloned
 # into the local root bazel cache
 # "-std=c++17" is needed in order to build with ZetaSQL.
 RUN bazel build -c opt --action_env=PATH \
@@ -63,9 +53,8 @@ ENV GRPC_PORT "8080"
 ENV METADATA_STORE_SERVER_CONFIG_FILE ""
 
 # Introduces tzdata package here to avoid LoadTimeZone check failed error in the metadata store server.
-RUN microdnf update -y && \
-  microdnf reinstall -y \
-  tzdata
+RUN microdnf reinstall -y tzdata && \
+    microdnf clean all
 
 USER 65534:65534
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The bazel5 RPMs used here from the galileo/bazel COPR repo are built
by grdryn for EL9 on EL9 builders in Fedora COPR
infrastructure. They're built for all 4 of our target architectures,
which means that we should be able to use it to build programs on all
of x86_64, aarch64, ppc64le, and s390x.

The patch that @PankhudiJ17 added to allow for ppc64le builds also
allows aarch64 builds when a similar change is made, so that's added
to the patch file here too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Built on x86_64, aarch64, and ppc64le on Konflux, index image reference can be found here:
```
quay.io/redhat-user-workloads/open-data-hub-tenant/ml-metadata-multi-arch-poc@sha256:1cc0e94038bb29c5da1f9c371da678602fb79e85d5792c9530fb310cdc09c299
```
- Verified that the image looks reasonable on aarch64, and starts:
```
➜ podman run --rm -ti --entrypoint bash quay.io/redhat-user-workloads/open-data-hub-tenant/ml-metadata-multi-arch-poc@sha256:1cc0e94038bb29c5da1f9c371da678602fb79e85d5792c9530fb310cdc09c299

bash-5.1$ cat /etc/system-release
Red Hat Enterprise Linux release 9.6 (Plow)
bash-5.1$ uname -a
Linux e46b95f078f1 6.15.3-200.fc42.aarch64 #1 SMP PREEMPT_DYNAMIC Thu Jun 19 15:27:43 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
bash-5.1$ ldd /bin/metadata_store_server 
	linux-vdso.so.1 (0x0000ffff9ec8f000)
	libm.so.6 => /lib64/libm.so.6 (0x0000ffff9eb9f000)
	libstdc++.so.6 => /lib64/libstdc++.so.6 (0x0000ffff9e97b000)
	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x0000ffff9e94a000)
	libc.so.6 => /lib64/libc.so.6 (0x0000ffff9e79c000)
	/lib/ld-linux-aarch64.so.1 (0x0000ffff9ec40000)
bash-5.1$ metadata_store_server
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0713 22:09:24.880488    12 metadata_store_server_main.cc:460] The connection_config is not given. Using in memory fake database, any metadata will not be persistent
I0713 22:09:24.887391    12 metadata_store_server_main.cc:639] Server listening on 0.0.0.0:8080
^C
```
- I didn't do any testing using any real use cases or make any requests against the running service, since I don't know how to do that yet.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for ARM 64-bit architectures by updating internal logic to correctly bypass unsupported CPU feature detection.

* **Chores**
  * Streamlined Bazel installation in the Red Hat-based Docker build environment for easier maintenance.
  * Simplified and optimized package management in the Docker runtime image to reduce image size and ensure timezone data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->