### PR TITLE
fix the zetasql_commit

### DIFF
--- a/.tekton/odh-mlmd-grpc-server-pull-request.yaml
+++ b/.tekton/odh-mlmd-grpc-server-pull-request.yaml
@@ -44,7 +44,7 @@ spec:
           computeResources:
             requests:
               cpu: '8'
-              memory: 16Gi
+              memory: 32Gi
             limits:
               cpu: '16'
               memory: 32Gi

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,7 +253,7 @@ http_archive(
 
 # TODO: can we import the proper zetasql version based on some config provided in the build command?
 # Required for Fedora39 and ubi8
-ZETASQL_COMMIT = "ac37cf5c0d80b5605176fc0f29e87b12f00be693" # 08/10/2022
+ZETASQL_COMMIT = "f764f4e986ac1516ab5ae95e6d6ce2f4416cc6ff" # 08/10/2022
 http_archive(
     name = "com_google_zetasql",
     urls = ["https://github.com/google/zetasql/archive/%s.zip" % ZETASQL_COMMIT],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ZetaSQL dependency to a newer commit with explicit archive checksum for stronger build verification.
  * Removed an obsolete patch entry related to that dependency.
  * Increased pipeline build memory request (16Gi → 32Gi) to support heavier builds.
  * Added a longer task-level timeout (4h) to improve handling of long-running pipeline tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->